### PR TITLE
Enforce store name to start with character

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -6,7 +6,7 @@ var randomString = require('random-string')
 
 var storeId = humbleLocalStorage.getItem('_storeId')
 if (!storeId) {
-  storeId = randomString({length: 7}).toLowerCase()
+  storeId = 'store-' + randomString({length: 7}).toLowerCase()
   humbleLocalStorage.setItem('_storeId', storeId)
 }
 


### PR DESCRIPTION
CouchDB databases _must_ start with a character. Our random ID
generator might sometimes return an id starting with a number,
which caused the `400 Bad Request` responses.

This PR prefixes the store names with `store-`. Make sure to
clear your localStorage to make sure that a new store.name
gets generated before testing it.

This fixes the issues mentioned here https://github.com/hoodiehq/hapi-couchdb-store/issues/2#issuecomment-129041481 and it closes #2 together with 9ddb84d