### PR TITLE
Update hapi@9.0.0

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -9,6 +9,12 @@ var plugin = require('../index')
 var server = new Hapi.Server()
 server.connection({ port: 3000 })
 
+server.register({
+  register: require('inert')
+}, function (error) {
+  if (error) throw error
+})
+
 // serve demo app at route path
 server.route({
   method: 'GET',
@@ -35,14 +41,21 @@ server.register({
 })
 
 server.register({
-  register: plugin
+  register: require('h2o2')
 }, function (error) {
   if (error) throw error
 })
 
-// enable CORS
-server.ext('onPreResponse', corsHeaders)
+server.register({
+  register: plugin
+}, function (error) {
+  if (error) throw error
 
-server.start(function () {
-  console.log('Server running at:', server.info.uri)
+  // enable CORS
+  server.ext('onPreResponse', corsHeaders)
+
+  server.start(function () {
+    console.log('Server running at:', server.info.uri)
+  })
 })
+

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "browserify": "^11.0.1",
     "good": "^6.3.0",
     "good-console": "^5.0.2",
-    "hapi": "^8.8.1",
+    "hapi": "^9.0.0",
     "hapi-cors-headers": "^1.0.0",
     "humble-localstorage": "^1.4.1",
     "joi": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "hapi": "^9.0.0",
     "hapi-cors-headers": "^1.0.0",
     "humble-localstorage": "^1.4.1",
+    "inert": "^3.0.1",
     "joi": "^6.6.1",
     "pouchdb-hoodie-store": "^1.0.1",
     "random-string": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "browserify": "^11.0.1",
     "good": "^6.3.0",
     "good-console": "^5.0.2",
+    "h2o2": "^4.0.1",
     "hapi": "^9.0.0",
     "hapi-cors-headers": "^1.0.0",
     "humble-localstorage": "^1.4.1",


### PR DESCRIPTION
Fixes #4 

The update to hapi@^9.0.0 removes the internal dependencies for `inert` and `h2o2`, which we use in the route handlers for the `server`, so I added them as dependencies to our project. 

I also ran into an issue with this message, `Error: Cannot start server before plugins finished registration`.  So I refactored the `server` to start after registering the plugin from `index.js`. 