### PR TITLE
Fixes endless store.sync() loop

### DIFF
--- a/lib/routes/couchdb-proxy.js
+++ b/lib/routes/couchdb-proxy.js
@@ -8,8 +8,9 @@ module.exports = {
       passThrough: true,
       mapUri: function (request, next) {
         var path = request.params.path || ''
+        var queryString = request.url.search || ''
         var server = request.connection.server
-        next(null, server.plugins['couchdb-store'].couchdb + '/' + path)
+        next(null, server.plugins['couchdb-store'].couchdb + '/' + path + queryString)
       }
     }
   },


### PR DESCRIPTION
Fixes #1 

Turns out the query params were not being passed through the `proxy` handler, so `pouchdb-server` was not able to properly sync with the local `pouchdb-hoodie-store`. 